### PR TITLE
Crypto/hash: remove side-effects, better define behavior for falsy amounts

### DIFF
--- a/packages/client/test/aergo_test.ts
+++ b/packages/client/test/aergo_test.ts
@@ -312,28 +312,6 @@ describe('Aergo', () => {
         });
     });
 
-    describe('sendLocallySignedTransactionWithoutAmount()', () => {
-        it('should return hash for comitted tx', async () => {
-            const identity = createIdentity();
-            const tx = {
-                nonce: 1,
-                from: identity.address,
-                to: identity.address,
-                amount: 'aer',
-                chainIdHash: await aergo.getChainIdHash(),
-                sign: null,
-                hash: null
-            };
-            tx.sign = await signTransaction(tx, identity.keyPair);
-            tx.hash = await hashTransaction(tx, 'bytes');
-
-            const txhash = await aergo.sendSignedTransaction(tx);
-            assert.typeOf(txhash, 'string');
-            const commitedTx = await aergo.getTransaction(txhash);
-            assert.equal(commitedTx.tx.amount.toString(), tx.amount.toString());
-        });
-    });
-
     describe('sendLocallySignedTransaction()', () => {
         it('should return hash for comitted tx', async () => {
             const identity = createIdentity();

--- a/packages/crypto/src/hashing.ts
+++ b/packages/crypto/src/hashing.ts
@@ -45,19 +45,17 @@ async function hashTransaction(tx: TxBody, encoding: 'base64', includeSign?: boo
 async function hashTransaction(tx: TxBody, encoding: 'base58', includeSign?: boolean): Promise<string>;
 async function hashTransaction(tx: TxBody, encoding: 'bytes', includeSign?: boolean): Promise<Buffer>;
 async function hashTransaction(tx: TxBody, encoding = 'base64', includeSign = true): Promise<Buffer | string> {
-    // check amount format
-    tx.amount = '' + tx.amount;
-    const amount = tx.amount.replace(/[^0-9]/g,'');
-
-    // check '' amount
-    if (!amount) {
-        tx.amount = '0 aer';
-    }
-
-    if (typeof tx.amount !== 'string') throw new Error(); // this is a type-hint for ts
-    const amountUnit = tx.amount.match(/\s*([^0-9]+)\s*/);
-    if (amountUnit && amountUnit[1] !== 'aer') {
-        throw Error(`Can only hash amounts provided in the base unit (aer), not ${tx.amount}. Convert to aer or remove unit.`);
+    // Amount defaults to zero if tx.amount is falsy
+    let amount = '0';
+    if (tx.amount) {
+        const amountStr = tx.amount.toString().trim();
+        // Throw error if unit is given other than aer
+        const amountUnit = amountStr.match(/\s*([^0-9]+)\s*/);
+        if (amountUnit && amountUnit[1] !== 'aer') {
+            throw Error(`Can only hash amounts provided in the base unit (aer), not ${tx.amount}. Convert to aer or remove unit.`);
+        }
+        // Strip unit
+        amount = amountStr.replace(/[^0-9]/g,'');
     }
 
     const items = [

--- a/packages/crypto/src/hashing.ts
+++ b/packages/crypto/src/hashing.ts
@@ -57,7 +57,7 @@ async function hashTransaction(tx: TxBody, encoding = 'base64', includeSign = tr
             }
             // Strip unit
             amount = amountStr.replace(/[^0-9]/g,'');
-            // If amount is an empty string at this point, throw an error
+            // Throw error if amount is an empty string at this point (amount with unit but without value)
             if (amount === '') {
                 throw Error(`Could not parse numeric value from amount '${tx.amount}'.`);
             }

--- a/packages/crypto/src/hashing.ts
+++ b/packages/crypto/src/hashing.ts
@@ -49,13 +49,19 @@ async function hashTransaction(tx: TxBody, encoding = 'base64', includeSign = tr
     let amount = '0';
     if (tx.amount) {
         const amountStr = tx.amount.toString().trim();
-        // Throw error if unit is given other than aer
-        const amountUnit = amountStr.match(/\s*([^0-9]+)\s*/);
-        if (amountUnit && amountUnit[1] !== 'aer') {
-            throw Error(`Can only hash amounts provided in the base unit (aer), not ${tx.amount}. Convert to aer or remove unit.`);
+        if (amountStr !== '') {
+            // Throw error if unit is given other than aer
+            const amountUnit = amountStr.match(/\s*([^0-9]+)\s*/);
+            if (amountUnit && amountUnit[1] !== 'aer') {
+                throw Error(`Can only hash amounts provided in the base unit (aer), not '${tx.amount}'. Convert to aer or remove unit.`);
+            }
+            // Strip unit
+            amount = amountStr.replace(/[^0-9]/g,'');
+            // If amount is an empty string at this point, throw an error
+            if (amount === '') {
+                throw Error(`Could not parse numeric value from amount '${tx.amount}'.`);
+            }
         }
-        // Strip unit
-        amount = amountStr.replace(/[^0-9]/g,'');
     }
 
     const items = [

--- a/packages/crypto/test/test.ts
+++ b/packages/crypto/test/test.ts
@@ -24,6 +24,23 @@ describe('createIdentity()', () => {
 });
 
 describe('hashTransaction()', () => {
+    it('should default amount to 0 and treat falsy values as 0', async () => {
+        const hashPromises = [];
+        const amounts = ['0 aer', 'aer', ' aer', ' ', '0', 0, '', false, null, undefined];
+        for (const amount of amounts) {
+            const tx = {
+                amount,
+                nonce: 1,
+                from: '',
+                chainIdHash: ''
+            };
+            hashPromises.push(hashTransaction(tx));
+        }
+        const hashes = await Promise.all(hashPromises);
+        for (const [idx, hash] of hashes.entries()) {
+            assert.equal(hash, hashes[0], `hash differs (idx: ${idx}, amount: ${amounts[idx]})`);
+        }
+    });
     it('should fail with invalid amount', async () => {
         const tx = {
             amount: '100000 aergo',


### PR DESCRIPTION
- Remove side-effects of `hashTransaction` (used to change `tx.amount`)
- All falsy amounts are converted to 0 now
- Amounts with unit but without value throw an error now
- Added a test with several amount cases to clarify behavior