### PR TITLE
Wallet: support for Ledger

### DIFF
--- a/packages/ledger-hw-app-aergo/test/test.ts
+++ b/packages/ledger-hw-app-aergo/test/test.ts
@@ -119,7 +119,6 @@ describe('sign and send', () => {
         // TODO: result.hash seems to be the signed message, not the finalized tx hash. Not very useful in this case.
         // Let's think about calculating the hash automatically in sendSignedTransaction if missing.
         // ATM, herajs/client does not depend on herajs/crypto. Maybe hashing should be in a 'common' package?
-        // Could also move some utils there, like encoding and polling w exponential backoff.
         // For now, let's calculate the hash here
         tx.hash = await hashTransaction(tx, 'bytes');
         const txHash = await aergo.sendSignedTransaction(tx);

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -35,5 +35,8 @@
     "idb": "^4.0.0",
     "level": "^6.0.0"
   },
-  "gitHead": "5c14921cf71bcb01d4103dfccba8c6b4ae335fd6"
+  "gitHead": "5c14921cf71bcb01d4103dfccba8c6b4ae335fd6",
+  "devDependencies": {
+    "@ledgerhq/hw-transport-node-hid": "^5.11.0"
+  }
 }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -25,8 +25,8 @@
   "dependencies": {
     "@elderapo/typed-event-emitter": "^1.4.1",
     "@herajs/client": "^0.19.1",
-    "@herajs/common": "^0.19.1",
-    "@herajs/crypto": "^0.19.1",
+    "@herajs/common": "^0.19.0",
+    "@herajs/crypto": "^0.19.0",
     "@herajs/ledger-hw-app-aergo": "^0.19.1",
     "@types/google-protobuf": "^3.2.7",
     "@types/hashmap": "^2.0.29",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -25,8 +25,9 @@
   "dependencies": {
     "@elderapo/typed-event-emitter": "^1.4.1",
     "@herajs/client": "^0.19.1",
-    "@herajs/common": "^0.19.0",
-    "@herajs/crypto": "^0.19.0",
+    "@herajs/common": "^0.19.1",
+    "@herajs/crypto": "^0.19.1",
+    "@herajs/ledger-hw-app-aergo": "^0.19.1",
     "@types/google-protobuf": "^3.2.7",
     "@types/hashmap": "^2.0.29",
     "@types/leveldown": "^4.0.0",

--- a/packages/wallet/src/models/account.ts
+++ b/packages/wallet/src/models/account.ts
@@ -16,11 +16,15 @@ export interface CompleteAccountSpec {
     chainId: string;
 }
 
+export type AccountType = '' | 'ledger';
+
 export interface AccountData extends Data {
     spec: {
         address: string;
         chainId: string;
     };
+    type: AccountType;
+    derivationPath: string;
     privateKey: number[];
     publicKey: number[];
     balance: string;
@@ -41,5 +45,8 @@ export class Account extends Record<AccountData> {
     }
     get address(): Address {
         return new Address(this.data.spec.address);
+    }
+    get type(): AccountType {
+        return this.data.type || '';
     }
 }

--- a/packages/wallet/src/models/transaction.ts
+++ b/packages/wallet/src/models/transaction.ts
@@ -52,18 +52,23 @@ export class Transaction extends Record<TransactionData> {
     }
 
     get unsignedHash(): string {
-        if (typeof this._unsignedHash === 'undefined') {
-            this._unsignedHash = this.getUnsignedHash();
-        }
+        if (typeof this._unsignedHash === 'undefined') throw new Error('transaction is missing hash, either supply or compute with getUnsignedHash()');
         return this._unsignedHash;
     }
 
     /**
      * Calculate the hash excluding any signature
      */
-    getUnsignedHash(): string {
-        // TODO calc hash
-        return '';
+    async getUnsignedHash(): Promise<string> {
+        if (typeof this.txBody === 'undefined') {
+            throw new Error('cannot get hash without txBody');
+        }
+        if (typeof this.txBody.nonce !== 'number') {
+            throw new Error('missing required parameter `nonce`');
+        }
+        const hash = await hashTransaction({ ...this.txBody, nonce: this.txBody.nonce || 0 }, 'base58');
+        this._unsignedHash = hash;
+        return hash;
     }
 
     get amount(): Amount {

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -8,6 +8,7 @@ import { Account, AccountSpec } from './models/account';
 import { TxBody, SignedTransaction } from './models/transaction';
 import { DEFAULT_CHAIN } from './defaults';
 import { Storage } from './storages/storage';
+import LedgerAppAergo from '@herajs/ledger-hw-app-aergo';
 
 const DB_VERSION = 1;
 
@@ -46,6 +47,7 @@ export class Wallet extends MiddlewareConsumer {
     public keystore?: Storage;
     private clients: Map<string, AergoClient> = new Map();
     public defaultLimit?: number;
+    public ledger?: LedgerAppAergo;
 
     constructor(config?: Partial<WalletConfig>) {
         super();
@@ -258,5 +260,9 @@ export class Wallet extends MiddlewareConsumer {
             await this.datastore.getIndex('transactions').clear();
             await this.datastore.getIndex('settings').clear();
         }
+    }
+
+    connectLedger(transport: any): void {
+        this.ledger = new LedgerAppAergo(transport);
     }
 }

--- a/packages/wallet/test/ledger_test.ts
+++ b/packages/wallet/test/ledger_test.ts
@@ -1,0 +1,55 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+const assert = chai.assert;
+import 'regenerator-runtime/runtime';
+
+import { Wallet } from '../src/wallet';
+import { TxTypes } from '@herajs/common';
+import Transport from '@ledgerhq/hw-transport-node-hid';
+
+let wallet: Wallet;
+async function getWallet(): Promise<Wallet> {
+    if (!wallet) {
+        wallet = new Wallet();
+        wallet.useChain({
+            chainId: 'testnet.localhost',
+            nodeUrl: '127.0.0.1:7845'
+        });
+        const transport = await Transport.create(3000, 1500);
+        wallet.connectLedger(transport);
+    }
+    return wallet;
+}
+
+describe('Hardware Wallet support', async () => {
+    if (process.env.CI) return; // This test can only be run locally
+    
+    it('gets address from Ledger', async () => {
+        const wallet = await getWallet();
+        const address = await wallet.accountManager.getAddressFromLedger('m/44\'/441\'/0\'/0/' + 1);
+        assert.equal(address[0], 'A');
+    });
+
+    it('sends tx (loads key, builds and commits tx, gets status updates)', async () => {
+        const wallet = await getWallet();
+        const path = 'm/44\'/441\'/0\'/0/' + 1;
+        const address = await wallet.accountManager.getAddressFromLedger(path);
+        const accountSpec = { address };
+        const account =  await wallet.accountManager.getOrAddAccount(accountSpec, { type: 'ledger', derivationPath: path });
+
+        // Create another address to check that Ledger does not get confused
+        const otherAddress = await wallet.accountManager.getAddressFromLedger('m/44\'/441\'/0\'/0/' + 2);
+        const tx = {
+            from: account.address,
+            to: otherAddress,
+            amount: '1 aergo',
+            type: TxTypes.Transfer,
+        };
+        // eslint-disable-next-line no-console
+        console.log('Confirm transaction on device...');
+        const txTracker = await wallet.sendTransaction(account, tx);
+        const receipt = await txTracker.getReceipt();
+        assert.equal(receipt.status, 'SUCCESS');
+    }).timeout(30000);
+});

--- a/packages/wallet/test/ledger_test.ts
+++ b/packages/wallet/test/ledger_test.ts
@@ -31,7 +31,7 @@ describe('Hardware Wallet support', async () => {
         assert.equal(address[0], 'A');
     });
 
-    it('sends tx (loads key, builds and commits tx, gets status updates)', async () => {
+    it('sends tx (builds and commits tx signed with Ledger)', async () => {
         const wallet = await getWallet();
         const path = 'm/44\'/441\'/0\'/0/' + 1;
         const address = await wallet.accountManager.getAddressFromLedger(path);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,6 +1000,15 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
+"@ledgerhq/devices@^5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.11.0.tgz#34c79e80539160df3116795ddb7d2aee904645e3"
+  integrity sha512-S+azwTA/L3g1l6ARN+rVYZeOu6b3uHxf6Ha5oj6UHbXxIdz1DyCVSUHz8SNrjDh0mUlbJugpAgaKBDdC2v9nNA==
+  dependencies:
+    "@ledgerhq/errors" "^5.11.0"
+    "@ledgerhq/logs" "^5.11.0"
+    rxjs "^6.5.4"
+
 "@ledgerhq/devices@^5.9.0":
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.9.0.tgz#f0fc230f0f9ad9eb39bbedf9b0a40900bdd6fe6b"
@@ -1008,6 +1017,11 @@
     "@ledgerhq/errors" "^5.9.0"
     "@ledgerhq/logs" "^5.9.0"
     rxjs "^6.5.4"
+
+"@ledgerhq/errors@^5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.11.0.tgz#722151b36ce1d53f555eeaae3e66f819c2362b28"
+  integrity sha512-o9Mx10+qZwuS6tKe6Z2mQJMClIvVtRNt/tdz4P/pNcGeT/0d6jdUfyF+J5P7RF3au0e9HTxG2LMCPFPZ2Tnibg==
 
 "@ledgerhq/errors@^5.9.0":
   version "5.9.0"
@@ -1025,6 +1039,17 @@
     "@ledgerhq/logs" "^5.9.0"
     node-hid "^1.2.0"
 
+"@ledgerhq/hw-transport-node-hid-noevents@^5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-5.11.0.tgz#6d400414dfc54defce4c765ea52481dcbb4505c9"
+  integrity sha512-egE2qaZEHkL89qjbWAnTEV3bYe5ALQRCCL8oTc8JVAu4JaxqCoro4DntXrBjjye7gT6gnUHgok1H5f/DVqX4aw==
+  dependencies:
+    "@ledgerhq/devices" "^5.11.0"
+    "@ledgerhq/errors" "^5.11.0"
+    "@ledgerhq/hw-transport" "^5.11.0"
+    "@ledgerhq/logs" "^5.11.0"
+    node-hid "^1.2.0"
+
 "@ledgerhq/hw-transport-node-hid@^5.10.0":
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-5.10.0.tgz#50ac3d2d9af2d90e35a91a948e476411cb323408"
@@ -1039,6 +1064,29 @@
     node-hid "^1.2.0"
     usb "^1.6.0"
 
+"@ledgerhq/hw-transport-node-hid@^5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-5.11.0.tgz#f2d3e0edc25840de4f452cf427a0482c65be8e86"
+  integrity sha512-J/hP3IqcgZn/sTGblELkwZcH68Gbv3ZeaRWdhei6K2dAuxae4dxoVUf6PoOcupEOcXT5XzJBNMc5800AwFeOgg==
+  dependencies:
+    "@ledgerhq/devices" "^5.11.0"
+    "@ledgerhq/errors" "^5.11.0"
+    "@ledgerhq/hw-transport" "^5.11.0"
+    "@ledgerhq/hw-transport-node-hid-noevents" "^5.11.0"
+    "@ledgerhq/logs" "^5.11.0"
+    lodash "^4.17.15"
+    node-hid "^1.2.0"
+    usb "^1.6.0"
+
+"@ledgerhq/hw-transport@^5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.11.0.tgz#f5c45a34d9b68d81fd2f6641b49815527720364b"
+  integrity sha512-z56iwv0DZZu20T5q9sNMHFQNVuRKYqzCuNFhY9woWSpmOQkyVHCRiEgOQbN5h6kVri6fkfPkDzqqcsYjJlnT9g==
+  dependencies:
+    "@ledgerhq/devices" "^5.11.0"
+    "@ledgerhq/errors" "^5.11.0"
+    events "^3.1.0"
+
 "@ledgerhq/hw-transport@^5.9.0":
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.9.0.tgz#580ab765774e10e40a1bb2c3402117b45da34011"
@@ -1047,6 +1095,11 @@
     "@ledgerhq/devices" "^5.9.0"
     "@ledgerhq/errors" "^5.9.0"
     events "^3.1.0"
+
+"@ledgerhq/logs@^5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.11.0.tgz#9ad2aefceeef48cf9d77972f67e63ba478dd04cc"
+  integrity sha512-NiFDdxLU/z1VGQy0/cbpv7UScMDQ/rU8SznqILSHYTnhK2xvvNFTUkd1W2mpmf9E/hzXFI0UAOieLQ44qovX3w==
 
 "@ledgerhq/logs@^5.9.0":
   version "5.9.0"


### PR DESCRIPTION
This adds functions to @herajs/wallet for Ledger support. If a Ledger transport is connected and an account is added with `{type: 'ledger'}`, signing operations will use Ledger.